### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -54,7 +54,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       try {
         // Run an actual nmap ping scan to discover hosts
         console.log(`Running nmap ping scan on ${cidr}...`);
-        const { stdout: nmapOutput } = await execAsync(`nmap -sn -T4 ${cidr}`);
+        const { stdout: nmapOutput } = await execAsync('nmap', ['-sn', '-T4', cidr]);
 
         // Parse nmap output to find hosts
         const hostLines = nmapOutput.split('\n').filter(line => line.includes('Nmap scan report for'));


### PR DESCRIPTION
Potential fix for [https://github.com/webmaster-exit-1/CySploit/security/code-scanning/2](https://github.com/webmaster-exit-1/CySploit/security/code-scanning/2)

To fix the issue, we should avoid using `execAsync` with a shell command that includes untrusted user input. Instead, we can use `execFile` or `execFileSync`, which do not spawn a shell and accept command arguments as an array. This approach ensures that the `cidr` value is treated as a literal argument rather than being interpreted by the shell.

Steps to fix:
1. Replace the use of `execAsync` with `execFile` or `execFileSync`.
2. Pass the `nmap` command and its arguments as an array, ensuring that the `cidr` value is treated safely.
3. Optionally, validate the `cidr` value to ensure it conforms to the expected format (e.g., a valid CIDR notation).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
