### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",


### PR DESCRIPTION
Potential fix for [https://github.com/webmaster-exit-1/CySploit/security/code-scanning/9](https://github.com/webmaster-exit-1/CySploit/security/code-scanning/9)

To address the issue, we will add rate limiting to the route handler using the `express-rate-limit` package. This package allows us to define a maximum number of requests that can be made to the endpoint within a specified time window. Specifically:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the package in `server/routes.ts`.
3. Define a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the `/scan/network` route.

This fix ensures that the route is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
