### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/cysploit-dist/server/routes.ts
+++ b/cysploit-dist/server/routes.ts
@@ -1,4 +1,5 @@
 import { Express, Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { Server } from 'http';
 import { networkInterfaces } from 'os';
 import { exec } from 'child_process';
@@ -26,7 +27,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // ===== Network Scanner Routes =====
 
   // Scan a network range
-  app.post(apiRouter('/scan/network'), async (req: Request, res: Response) => {
+  const scanNetworkLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 10, // Limit each IP to 10 requests per windowMs
+    message: { message: 'Too many requests, please try again later.' }
+  });
+
+  app.post(apiRouter('/scan/network'), scanNetworkLimiter, async (req: Request, res: Response) => {
     try {
       const { cidr } = req.body;
       


### PR DESCRIPTION
Potential fix for [https://github.com/webmaster-exit-1/CySploit/security/code-scanning/5](https://github.com/webmaster-exit-1/CySploit/security/code-scanning/5)

To address the issue, we will introduce rate limiting to the route handler on line 29. The `express-rate-limit` package will be used to limit the number of requests a client can make to this route within a specified time window. This will mitigate the risk of DoS attacks by ensuring that the system command is not executed excessively.

Steps to implement the fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 10 requests per minute).
4. Apply the rate limiter middleware to the `/scan/network` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
